### PR TITLE
Fixes issue #3

### DIFF
--- a/editor/plugins/scrubbable.html
+++ b/editor/plugins/scrubbable.html
@@ -43,11 +43,11 @@
       var self = this;
       handleDrag(el, {
         start: function(e) {
-          origin = { x: e.x, y: e.y };
+          origin = { x: e.clientX, y: e.clientY };
           document.body.classList.add('mc-scrubbing');
         },
         drag: function(e) {
-          el.textContent = originalValue + (e.x - origin.x);
+          el.textContent = originalValue + (e.clientX - origin.x);
         },
         end: function(e) {
           document.body.classList.remove('mc-scrubbing');


### PR DESCRIPTION
Firefox's mouse events have no .x and .y properties, they're called .clientX and .clientY.

[According to the mdn](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/clientX#Browser_compatibility), clientX and clientY are supported on all major browsers.
