### PR TITLE
Changed dependency es6-symbol to fixed 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Patrick Dubroy <pdubroy@gmail.com> (http://dubroy.com)",
   "license": "MIT",
   "dependencies": {
-    "es6-symbol": "^0.1.0",
+    "es6-symbol": "0.1.0",
     "esprima": "~1.1.1",
     "estraverse": "~1.5.0",
     "underscore": "*"


### PR DESCRIPTION
Changing the dependency on es6-symbol from `^0.1.0` to `0.1.0` fixes issue #2
