### PR TITLE
Updated expanders' symbols dependency

### DIFF
--- a/node_modules/expanders/package.json
+++ b/node_modules/expanders/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "main": "main.js",
   "dependencies": {
-    "es6-symbol": "^0.1.0"
+    "es6-symbol": "2.0.1"
   },
   "devDependencies": {
     "browserify": "^5.9.1",


### PR DESCRIPTION
After the last patch, npm reported that expanders' symbol dependency wasn't met, because it was still at `^0.1.0`, upgrading that to 2.0.1 also.
